### PR TITLE
Update readme with kubernetes-docs-id project

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Catatan: Proyek OSS Anda ingin dijebloskan ke sini? Silakan kirim PR (pull reque
 Berikut adalah proyek OSS yang dikerjakan oleh pekerja perusahaan, misalnya perekayasawan/wati (_software engineer_), sebagai bagian dari lingkup kerja resmi mereka.
 
 * [github.com/hyperjumptech/grule-rule-engine](https://github.com/hyperjumptech/grule-rule-engine): A rule engine library for Golang programming language. Inspired by the acclaimed JBOSS Drools, done in a much simple manner.
+* [github.com/kubernetes/website](https://github.com/kubernetes/website/tree/master/content/id): Sebuah proyek lokalisasi dokumentasi Kubernetes ke dalam bahasa Indonesia [kubernetes.io/id](https://kubernetes.io/id), dikelola oleh [SIG Docs ID](https://github.com/jk8s/sig-docs-id) dan [Komunitas Kubernetes/CloudNative Indonesia](https://github.com/cloudnative-id/meetups). Gabung di Slack channel [#kubernetes-docs-id](https://kubernetes.slack.com/archives/CJ1LUCUHM) untuk memulai kontribusi.
 
 ## Proyek OSS Pribadi
 


### PR DESCRIPTION
Add kubernetes-docs-id project as part of sub-project of SIG Docs in the upstream Kubernetes community.